### PR TITLE
Bump version to v0.15.47

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         else
           echo platform=linux-x86_64 >> $GITHUB_OUTPUT
         fi
-        echo version=v0.15.46 >> $GITHUB_OUTPUT
+        echo version=v0.15.47 >> $GITHUB_OUTPUT
       shell: bash
 
     - id: check-cache


### PR DESCRIPTION
Automated version bump: replace `version=v\d+\.\d+\.\d+[\w.+-]*` with `version=v0.15.47` in `action.yml`.